### PR TITLE
interface version bump for Midnight

### DIFF
--- a/Loot-A-Rang-Matic-Reforged.toc
+++ b/Loot-A-Rang-Matic-Reforged.toc
@@ -1,4 +1,4 @@
-## Interface: 110205
+## Interface: 120000
 ## Title: Loot-A-Rang Matic Reforged
 ## Notes: An addon that allows the use of the Loot-A-Rang with a double right click of the mouse.
 ## Author: Ranoth_


### PR DESCRIPTION
the addon works fine but because Midnight has disabled the "Load out of date Addons" functionality - this version needs to be bumped explicitly.